### PR TITLE
2020-03 release

### DIFF
--- a/src/java2yaml/Common/ConfigLoader.cs
+++ b/src/java2yaml/Common/ConfigLoader.cs
@@ -9,37 +9,6 @@
 
     public static class ConfigLoader
     {
-        // Load configuration from code2yaml.json and repo.json
-        public static ConfigModel LoadConfig(string configPath, string repoListPath)
-        {
-            if (string.IsNullOrWhiteSpace(configPath) || string.IsNullOrWhiteSpace(repoListPath))
-            {
-                throw new ArgumentException($"{nameof(configPath)} or {nameof(repoListPath)} cannot be null or empty.");
-            }
-
-            var config = JsonConvert.DeserializeObject<ConfigModel>(File.ReadAllText(configPath));
-
-            config.InputPaths = (from p in config.InputPaths
-                                 select TransformPath(configPath, p)).ToList();
-
-            config.OutputPath = TransformPath(configPath, config.OutputPath);
-
-            if (config.ExcludePaths != null)
-            {
-                config.ExcludePaths = (from p in config.ExcludePaths
-                                       select TransformPath(configPath, p)).ToList();
-            }
-
-            config.RepositoryFolders = LoadRepositoryList(repoListPath);
-
-            if (string.IsNullOrWhiteSpace(config.OutputPath))
-            {
-                throw new InvalidDataException($"Invalid \"{Constants.OutputPath}\" in {configPath}");
-            }
-
-            return config;
-        }
-
         // Load configuration from package.json
         public static List<ConfigModel> LoadConfig(string packageConfigPath)
         {

--- a/src/java2yaml/Common/ConfigLoader.cs
+++ b/src/java2yaml/Common/ConfigLoader.cs
@@ -21,42 +21,33 @@
 
             var packageBasedConfigs = JsonConvert.DeserializeObject<List<PackageBasedConfigModel>>(File.ReadAllText(packageConfigPath));
 
-            foreach(var config in packageBasedConfigs)
+            foreach (var config in packageBasedConfigs)
             {
                 var folderList = LoadPackageFolders(packageConfigPath, config);
-
                 var excludePaths = LoadExcludePaths(packageConfigPath, config);
+                var packages = config.Packages
+                            .Select(x => new PackageConfigModel(config.OutputPath, packageConfigPath, x))
+                            .ToList();
 
-                // the path of unzipped -soruce.jar will be consider as inputPath, as it contains all the .java files we need to document for each artifact.
-                configs.Add(new ConfigModel
+                var packageConfig = new ConfigModel()
                 {
+                    OutputPath = PathUtility.TransformPath(packageConfigPath, config.OutputPath),
                     InputPaths = folderList,
-                    OutputPath = TransformPath(packageConfigPath, config.OutputPath),
                     ExcludePaths = excludePaths,
-                    RepositoryFolders = folderList
-                });               
+                    PackageConfigs = packages
+                };
+
+                configs.Add(packageConfig);
             }
 
             return configs;
-        }
-
-        public static List<string> LoadRepositoryList(string repoListPath)
-        {
-            var repos = JsonConvert.DeserializeObject<RepositoryModel>(File.ReadAllText(repoListPath)).Repository;
-
-            var list = (from p in repos
-                        let FolderName = Path.Combine(Constants.Src, p.FolderName)
-                        select TransformPath(repoListPath, FolderName))
-                .ToList();
-
-            return list;
         }
 
         private static List<string> LoadPackageFolders(string configPath, PackageBasedConfigModel packageBasedConfig)
         {
             return (from p in packageBasedConfig.Packages
                     let FolderName = Path.Combine(Constants.Src, packageBasedConfig.OutputPath, p.ArtifactId)
-                    select TransformPath(configPath, FolderName))
+                    select PathUtility.TransformPath(configPath, FolderName))
             .ToList();
         }
 
@@ -66,13 +57,8 @@
                     where p.ExcludePaths != null
                     from e in p.ExcludePaths
                     let FolderName = Path.Combine(Constants.Src, packageConfig.OutputPath, p.ArtifactId, e)
-                    select TransformPath(configPath, FolderName))
+                    select PathUtility.TransformPath(configPath, FolderName))
             .ToList();
-        }
-
-        private static string TransformPath(string configPath, string path)
-        {
-            return PathUtility.IsRelativePath(path) ? PathUtility.GetAbsolutePath(configPath, path) : path;
         }
     }
 }

--- a/src/java2yaml/Common/Utility/CopyUtility.cs
+++ b/src/java2yaml/Common/Utility/CopyUtility.cs
@@ -13,7 +13,7 @@
 
             foreach (var file in sourcePath)
             {
-                File.Copy(file, Path.Combine(targetPath, Path.GetFileName(file)), overwrite: true);
+                CopyFile(file,Path.Combine(targetPath, Path.GetFileName(file)), true);
             }
         }
 
@@ -31,8 +31,15 @@
         public static void CopyFile(string sourcePath, string targetPath, string fileName)
         {
             var filePath = Path.Combine(sourcePath, fileName);
+            CopyFile(filePath, Path.Combine(targetPath, Path.GetFileName(filePath)), true);
+        }
 
-            File.Copy(filePath, Path.Combine(targetPath, Path.GetFileName(filePath)), overwrite: true);
+        internal static void CopyFile(string source, string target, bool isOverWrite = true)
+        {
+            Guard.ArgumentNotNullOrEmpty(source, nameof(source));
+            Guard.ArgumentNotNullOrEmpty(target, nameof(target));
+
+            File.Copy(PathUtility.ResolveLongPath(source), PathUtility.ResolveLongPath(target), overwrite: isOverWrite);
         }
 
         private static bool IsExclude(List<string> exclusion, string fileName)

--- a/src/java2yaml/Common/Utility/PathUtility.cs
+++ b/src/java2yaml/Common/Utility/PathUtility.cs
@@ -71,6 +71,11 @@
             return Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
         }
 
+        // This snippet requires Framework 4.6.2, NDP462-DevPack-KB3151934 installed, and configraiton in .csproj
+        public static string ResolveLongPath(string path)
+        {
+            return String.Concat(@"\\?\", path);
+        }
     }
 
     public class FilePathComparer

--- a/src/java2yaml/Common/Utility/PathUtility.cs
+++ b/src/java2yaml/Common/Utility/PathUtility.cs
@@ -76,6 +76,11 @@
         {
             return String.Concat(@"\\?\", path);
         }
+
+        public static string TransformPath(string filePath, string path)
+        {
+            return IsRelativePath(path) ? GetAbsolutePath(filePath, path) : path;
+        }
     }
 
     public class FilePathComparer

--- a/src/java2yaml/Constants/Constants.cs
+++ b/src/java2yaml/Constants/Constants.cs
@@ -2,19 +2,21 @@
 {
     public static class Constants
     {
-        public const string ConfigFileName = "Code2Yaml.json";
-        public const string RepoListFileName = "Repo.json";
-
         public const string packageConfigFileName = "Package.json";
 
         public const string Config = "config";
-        public const string InputPaths = "input_paths";
         public const string OutputPath = "output_path";
-        public const string ExcludePaths = "exclude_paths";
+
         public const string Language = "language";
         public const string Repo = "repo";
         public const string FolderName = "name";
+
         public const string ArtifactId = "packageArtifactId";
+        public const string GroupId = "packageGroupId";
+        public const string PackageVersion = "packageVersion";
+        public const string InputPaths = "inputPaths";
+        public const string ExcludePaths = "excludePaths";
+        public const string ExcludePackages = "excludePackages";
 
         public const string Src = @"src\";
         public const string Doc = "_javadocs";

--- a/src/java2yaml/DataContracts/ConfigModel/ConfigModel.cs
+++ b/src/java2yaml/DataContracts/ConfigModel/ConfigModel.cs
@@ -2,14 +2,18 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
 
     using Newtonsoft.Json;
 
     [Serializable]
     public class ConfigModel
     {
-        [JsonProperty(Constants.InputPaths, Required = Required.DisallowNull)]
+        [JsonProperty(Constants.InputPaths)]
         public List<string> InputPaths { get; set; }
+
+        [JsonProperty(Constants.ExcludePaths)]
+        public List<string> ExcludePaths { get; set; }
 
         [JsonProperty(Constants.OutputPath, Required = Required.DisallowNull)]
         public string OutputPath { get; set; }
@@ -17,9 +21,19 @@
         [JsonProperty(Constants.Language)]
         public string Language { get; set; } = "java";
 
-        [JsonProperty(Constants.ExcludePaths)]
-        public List<string> ExcludePaths { get; set; }
+        public List<PackageConfigModel> PackageConfigs { get; set; }
+    }
 
-        public List<string> RepositoryFolders { get; set; }
+    public class PackageConfigModel
+    {
+        public string RepositoryFolder { get; set; }
+
+        public Package Package { get; set; }
+
+        public PackageConfigModel(string outputPath, string configPath, Package package)
+        {
+            RepositoryFolder = PathUtility.TransformPath(configPath, Path.Combine(Constants.Src, outputPath, package.ArtifactId));
+            Package = package;
+        }
     }
 }

--- a/src/java2yaml/DataContracts/ConfigModel/PackageBasedConfigModel.cs
+++ b/src/java2yaml/DataContracts/ConfigModel/PackageBasedConfigModel.cs
@@ -22,10 +22,19 @@
         [JsonProperty(Constants.ArtifactId, Required = Required.DisallowNull)]
         public string ArtifactId { get; set; }
 
+        [JsonProperty(Constants.GroupId, Required = Required.DisallowNull)]
+        public string GroupId { get; set; }
+
+        [JsonProperty(Constants.PackageVersion, Required = Required.DisallowNull)]
+        public string PackageVersion { get; set; }
+
         [JsonProperty(Constants.InputPaths)]
         public List<string> InputPaths { get; set; }
 
         [JsonProperty(Constants.ExcludePaths)]
         public List<string> ExcludePaths { get; set; }
+
+        [JsonProperty(Constants.ExcludePackages)]
+        public string ExcludePackages { get; set; }
     }
 }

--- a/src/java2yaml/Program.cs
+++ b/src/java2yaml/Program.cs
@@ -67,43 +67,12 @@
             {
                 return ValidateByPackageBased(args);
             }
-            else if (args.Length == 0 || args.Length == 2)
-            {
-                return ValidateBySouceBased(args);
-            }
             else
             {
                 Console.Error.WriteLine("Unrecognized parameters.");
-                Console.Error.WriteLine("Source-based Usage : Java2Yaml.exe [code2yaml.json, repo.json]");
                 Console.Error.WriteLine("Package-based Usage : Java2Yaml.exe [package.json]");
                 return false;
             }
-        }
-
-        private static bool ValidateBySouceBased(string[] args)
-        {
-            string configPath = args.Length == 0 ? Constants.ConfigFileName : args[0];
-            string repoListPath = args.Length == 0 ? Constants.RepoListFileName : args[1];
-
-            if (!File.Exists(configPath) || !File.Exists(repoListPath))
-            {
-                Console.Error.WriteLine($"Cannot find config file: {configPath} or {repoListPath}");
-                return false;
-            }
-
-            try
-            {
-                _configs.Add(ConfigLoader.LoadConfig(Path.GetFullPath(configPath), Path.GetFullPath(repoListPath)));
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine($"Fail to deserialize config files: {configPath}, {repoListPath} . Exception: {ex}");
-                return false;
-            }
-
-            Console.WriteLine($"Config files {configPath}, {repoListPath} found. Start processing...");
-
-            return true;
         }
 
         private static bool ValidateByPackageBased(string[] args)

--- a/src/java2yaml/Program.cs
+++ b/src/java2yaml/Program.cs
@@ -39,7 +39,7 @@
                     {
                         Phase = "Initialize",
                         Level = LogLevel.Info,
-                        Message = $" {config.RepositoryFolders.Count} package(s) to process, target folder: '{config.OutputPath}'"
+                        Message = $" {config.PackageConfigs.Count} package(s) to process, target folder: '{config.OutputPath}'"
                     });
 
                     await procedure.RunAsync(config);

--- a/src/java2yaml/Properties/launchSettings.json
+++ b/src/java2yaml/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "java2yaml": {
+      "commandName": "Project",
+      "commandLineArgs": "D:\\JavaWorkItem\\OnBoardAzuremgt\\FixAzureMgt\\target_repo\\package.json"
+    }
+  }
+}

--- a/src/java2yaml/Steps/CentralizeDocument.cs
+++ b/src/java2yaml/Steps/CentralizeDocument.cs
@@ -19,9 +19,9 @@
                     Directory.CreateDirectory(targetPath);
                 }
 
-                foreach (var repositoryPath in config.RepositoryFolders)
+                foreach (var packageConfig in config.PackageConfigs)
                 {
-                    var sourcePath = Path.Combine(repositoryPath, Constants.Doc);
+                    var sourcePath = Path.Combine(packageConfig.RepositoryFolder, Constants.Doc);
 
                     ConsoleLogger.WriteLine(new LogEntry
                     {

--- a/src/java2yaml/Steps/GenerateDocument.cs
+++ b/src/java2yaml/Steps/GenerateDocument.cs
@@ -10,11 +10,11 @@
         {
             return Task.Run(async () =>
             {
-                foreach (var path in config.RepositoryFolders)
+                foreach (var packageConfig in config.PackageConfigs)
                 {
                     var procedure = new StepCollection(
-                        new RestoreDependency(path),
-                        new RunJavadoc(path));
+                        new RestoreDependency(packageConfig.RepositoryFolder),
+                        new RunJavadoc(packageConfig.RepositoryFolder, packageConfig.Package));
 
                     await procedure.RunAsync(config);
                 }

--- a/src/java2yaml/Steps/GenerateToc.cs
+++ b/src/java2yaml/Steps/GenerateToc.cs
@@ -24,9 +24,9 @@
                 _config = config;
                 var targetPath = Path.Combine(Directory.GetParent(config.OutputPath).ToString(), Constants.Doc);
 
-                if (_config.RepositoryFolders.Count == 1)
+                if (_config.PackageConfigs.Count == 1)
                 {
-                    var sourcePath = Path.Combine(config.RepositoryFolders[0], Constants.Doc);
+                    var sourcePath = Path.Combine(config.PackageConfigs.FirstOrDefault().RepositoryFolder, Constants.Doc);
 
                     ConsoleLogger.WriteLine(new LogEntry
                     {
@@ -65,8 +65,10 @@
 
         private List<string> GetTocList()
         {
-            return ( _config.RepositoryFolders
-                    .Select(path => FileUtility.GetFilesByName(Path.Combine(path, Constants.Doc), Constants.Toc).First())
+            return ( _config.PackageConfigs
+                    .Select(packageConfig => FileUtility.GetFilesByName(
+                        Path.Combine(packageConfig.RepositoryFolder, Constants.Doc), Constants.Toc).First()
+                        )
                     .Select(x => x.FullName.ToString())
                     .ToList()
             );

--- a/src/java2yaml/Steps/RestoreDependency.cs
+++ b/src/java2yaml/Steps/RestoreDependency.cs
@@ -15,6 +15,11 @@
 
         public string RepositoryPath { get; }
 
+        // This is profiles to exclude unpublished test jar packages when download dependencies
+        // For some packages, their test jar does not publish to Maven Central but they cannot be removed from pom
+        // But copy-dependencies must go through test scope, so work around by putting test jar to a profile, and skip this profile
+        public string[] MavenProfileToExclude = new string[1] { "!azure-mgmt-sdk-test-jar" };
+
         public Task RunAsync(ConfigModel config)
         {
             return Task.Run(() =>
@@ -46,7 +51,9 @@
 
         private void RunRestoreCommand(string packagePath, string workingDirectory)
         {
-            string commandLineArgs = string.Concat("/c mvn dependency:copy-dependencies -DoutputDirectory=", packagePath);
+            string profilesToExclude = string.Join(",", MavenProfileToExclude);
+
+            string commandLineArgs = string.Concat("/c mvn dependency:copy-dependencies -P ", profilesToExclude, " -DoutputDirectory=", packagePath);
 
             ConsoleLogger.WriteLine(new LogEntry
             {

--- a/src/shared/base.props
+++ b/src/shared/base.props
@@ -1,6 +1,11 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <configuration>
+    <runtime>
+      <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false;Switch.System.IO.BlockLongPaths=false" />
+    </runtime>
+    </configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputPath Condition="'$(OutputPath)'==''">$(MSBuildThisFileDirectory)..\..\target\$(Configuration)\$(MSBuildProjectName)\</OutputPath>
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
1. Stop supporting using repository as source input
2. Fix long path(full path has more than 260 characters)
3.Support using excludePackages as parameter
4.Add "-P" parameter for "mvn dependency:copy-dependencies" to exclude some unpublished dependencies