### PR TITLE
add prefix in exception message to make sure Azure pipeline can recognize

### DIFF
--- a/src/java2yaml/Common/Utility/ExceptionUtility.cs
+++ b/src/java2yaml/Common/Utility/ExceptionUtility.cs
@@ -1,0 +1,46 @@
+﻿
+namespace Microsoft.Content.Build.Java2Yaml
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+
+    public class ExceptionUtility
+    {
+        private const string prefix = "##vso[task.logissue type=error;]java2yaml";
+
+        public static void ThrowExceptionForAzureDevops(string fileName, string commandLineArgs, StringBuilder output, StringBuilder error)
+        {
+            string message = "";
+
+            switch (fileName.Trim())
+            {
+                case "cmd.exe":
+                    // cmd.exe will invoke mvn command, which writes everything into output, we need extract lines. 
+                    message = GetMVNErrorFromOutput(output);
+                    break;
+                case "javadoc.exe":
+                    message = $"{output.ToString()}. Error: {error.ToString()}.";
+                    break;
+            }
+
+            // for Azure DevOps to pick up excpetion
+            Console.WriteLine($"{prefix} '\"{fileName}\" {commandLineArgs}' failed. {ReplaceWithSpace(message)}");
+        }
+
+        private static string GetMVNErrorFromOutput(StringBuilder output)
+        {
+            List<string> errors = output.ToString().Split('\n').ToList()
+                .Where(s => s.StartsWith("[ERROR]"))
+                .ToList();
+
+            return string.Join(" ", errors);
+        }
+
+        private static string ReplaceWithSpace(string message)
+        {
+            return message.Replace('\n', ' ').Replace('\r', ' ');
+        }
+    }
+}

--- a/src/java2yaml/Common/Utility/ProcessUtility.cs
+++ b/src/java2yaml/Common/Utility/ProcessUtility.cs
@@ -44,7 +44,8 @@
             }
             else
             {
-                var message = $"##[error]java2yaml '\"{fileName}\" {commandLineArgs}' failed in directory '{cwd}' with exit code {process.ExitCode}: \nSTDOUT:'{output}'\nSTDERR:\n'{error}'";
+                ExceptionUtility.ThrowExceptionForAzureDevops(fileName, commandLineArgs, output, error);
+                var message = $"'\"{fileName}\" {commandLineArgs}' failed in directory '{cwd}' with exit code {process.ExitCode}: \nSTDOUT:'{output}'\nSTDERR:\n'{error}'";
                 throw new InvalidOperationException(message);
             }
         }


### PR DESCRIPTION
prefix "##vso[task.logissue type=error;]" has to be added to the exception message, then Azure Pipeline will recognize it as error.