### PR TITLE
Exclude packages with implemetation in namespace

### DIFF
--- a/src/java2yaml/Configs/excludeConfigs.txt
+++ b/src/java2yaml/Configs/excludeConfigs.txt
@@ -1,0 +1,1 @@
+﻿.*implementation.*

--- a/src/java2yaml/Constants/Constants.cs
+++ b/src/java2yaml/Constants/Constants.cs
@@ -17,6 +17,7 @@
         public const string InputPaths = "inputPaths";
         public const string ExcludePaths = "excludePaths";
         public const string ExcludePackages = "excludePackages";
+        public const string ExcludePackagesPath = "Configs/excludeConfigs.txt";
         public const string DocletPath = "docletPath";
 
         public const string Src = @"src\";

--- a/src/java2yaml/Constants/Constants.cs
+++ b/src/java2yaml/Constants/Constants.cs
@@ -17,7 +17,7 @@
         public const string InputPaths = "inputPaths";
         public const string ExcludePaths = "excludePaths";
         public const string ExcludePackages = "excludePackages";
-        public const string ExcludePackagesPath = "Configs/excludeConfigs.txt";
+        public const string ExcludePackagesPath = "src/java2yaml/Configs/excludeConfigs.txt";
         public const string DocletPath = "docletPath";
 
         public const string Src = @"src\";

--- a/src/java2yaml/Program.cs
+++ b/src/java2yaml/Program.cs
@@ -1,10 +1,5 @@
 ﻿namespace Microsoft.Content.Build.Java2Yaml
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.IO;
-    using System.Threading.Tasks;
 
     class Program
     {

--- a/src/java2yaml/Program.cs
+++ b/src/java2yaml/Program.cs
@@ -1,5 +1,10 @@
 ﻿namespace Microsoft.Content.Build.Java2Yaml
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Threading.Tasks;
 
     class Program
     {

--- a/src/java2yaml/Steps/RunJavadoc.cs
+++ b/src/java2yaml/Steps/RunJavadoc.cs
@@ -1,23 +1,25 @@
 ﻿namespace Microsoft.Content.Build.Java2Yaml
 {
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
 
     public class RunJavadoc : IStep
     {
+
         public RunJavadoc(string path, Package package)
         {
             RepositoryPath = path;
             ExcludePackages = package.ExcludePackages;
-            if (_excludeConfigs != null)
-            {
-                _excludeConfigs = loadExcludeRegexes(ExcludePackages);
-            }
+            loadExcludeRegexes(ExcludePackages);
         }
 
         public string StepName => "RunJavadoc";
 
         public string RepositoryPath { get; }
         public string ExcludePackages { get; }
-        private static string _excludeConfigs { get; }
 
         private static ConfigModel _config;
 
@@ -155,7 +157,7 @@
         private string loadExcludeRegexes(string excludePackages)
         {
             StringBuilder excludeStringBuilder = new StringBuilder();
-            string[] lines = System.IO.File.ReadAllLines(Constants.ExcludePackagesPath);
+            string[] lines = File.ReadAllLines(Constants.ExcludePackagesPath);
             foreach (string line in lines)
             {
                 excludeStringBuilder.Append(line + ":");

--- a/src/java2yaml/Steps/RunJavadoc.cs
+++ b/src/java2yaml/Steps/RunJavadoc.cs
@@ -1,10 +1,5 @@
 ﻿namespace Microsoft.Content.Build.Java2Yaml
 {
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
 
     public class RunJavadoc : IStep
     {
@@ -12,14 +7,20 @@
         {
             RepositoryPath = path;
             ExcludePackages = package.ExcludePackages;
+            if (_excludeConfigs != null)
+            {
+                _excludeConfigs = loadExcludeRegexes(ExcludePackages);
+            }
         }
 
         public string StepName => "RunJavadoc";
 
         public string RepositoryPath { get; }
         public string ExcludePackages { get; }
+        private static string _excludeConfigs { get; }
 
         private static ConfigModel _config;
+
 
         public Task RunAsync(ConfigModel config)
         {
@@ -94,7 +95,7 @@
                 options += " -excludePackages " + excludePackages;
             }
 
-                return options;
+            return options;
         }
 
         private string GetDependencies(string repositoryPath)
@@ -149,6 +150,18 @@
         private bool InExcludePaths(string dir)
         {
             return _config.ExcludePaths.Any(p => dir.StartsWith(p));
+        }
+
+        private string loadExcludeRegexes(string excludePackages)
+        {
+            StringBuilder excludeStringBuilder = new StringBuilder();
+            string[] lines = System.IO.File.ReadAllLines(Constants.ExcludePackagesPath);
+            foreach (string line in lines)
+            {
+                excludeStringBuilder.Append(line + ":");
+            }
+
+            return excludePackages + ":" + excludeStringBuilder.ToString().TrimEnd(':');
         }
     }
 }

--- a/src/java2yaml/Steps/RunJavadoc.cs
+++ b/src/java2yaml/Steps/RunJavadoc.cs
@@ -12,8 +12,7 @@
         public RunJavadoc(string path, Package package)
         {
             RepositoryPath = path;
-            ExcludePackages = package.ExcludePackages;
-            loadExcludeRegexes(ExcludePackages);
+            ExcludePackages = loadExcludeRegexes(package.ExcludePackages);
         }
 
         public string StepName => "RunJavadoc";
@@ -157,13 +156,18 @@
         private string loadExcludeRegexes(string excludePackages)
         {
             StringBuilder excludeStringBuilder = new StringBuilder();
+            // Throw file exception if IO call failed.
             string[] lines = File.ReadAllLines(Constants.ExcludePackagesPath);
+            
             foreach (string line in lines)
             {
                 excludeStringBuilder.Append(line + ":");
             }
-
-            return excludePackages + ":" + excludeStringBuilder.ToString().TrimEnd(':');
+            if (excludeStringBuilder.Length > 0)
+            {
+                excludePackages += ":" + excludeStringBuilder.ToString();
+            }
+            return excludePackages;
         }
     }
 }

--- a/src/java2yaml/Steps/RunJavadoc.cs
+++ b/src/java2yaml/Steps/RunJavadoc.cs
@@ -1,5 +1,6 @@
 ﻿namespace Microsoft.Content.Build.Java2Yaml
 {
+    using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
@@ -155,14 +156,22 @@
 
         private string loadExcludeRegexes(string excludePackages)
         {
-            StringBuilder excludeStringBuilder = new StringBuilder();
-            // Throw file exception if IO call failed.
-            string[] lines = File.ReadAllLines(Constants.ExcludePackagesPath);
-            
-            foreach (string line in lines)
+            StringBuilder excludeStringBuilder = new();
+
+            // Silent on any exception thrown by IO.
+            try
             {
-                excludeStringBuilder.Append(line + ":");
+                string[] lines = File.ReadAllLines(Constants.ExcludePackagesPath);
+                foreach (string line in lines)
+                {
+                    excludeStringBuilder.Append(line + ":");
+                }
             }
+            catch 
+            {
+                return excludePackages;
+            }
+            
             if (excludeStringBuilder.Length > 0)
             {
                 excludePackages += ":" + excludeStringBuilder.ToString();


### PR DESCRIPTION
**Purpose of PR**
We are lack of the ability to exclude internal APIs by default. It has to config for every services on board.
**Design doc**
https://microsoft.sharepoint.com/:w:/t/AzureDeveloperExperience/ESXa-xUDB-tDqTEXWHjS2pABx18P4uZlK1N8NGEAMOaFLw?e=iDPiVf

** Tests locally **
I have verified the results do not include any implementation packages by having the code.

* Screenshot for having implementation exclusion
<img width="367" alt="image" src="https://user-images.githubusercontent.com/48036328/146464359-f4ac9e29-610e-43f9-b9c0-6b34e96a7958.png">

* Screenshot for no implementation exclusion
<img width="465" alt="image" src="https://user-images.githubusercontent.com/48036328/146464092-c5e9e972-0efb-4d3b-8c49-b4df8269ccac.png">

